### PR TITLE
useTransition

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,13 +3,15 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 // import { SyntheticEvent } from './SyntheticEvent/index.tsx';
 // import { Propagation } from './SyntheticEvent/propagation.tsx';
-import { UpdateState } from './UpdateState/UpdateState.tsx';
+// import { UpdateState } from './UpdateState/UpdateState.tsx';
+import { Transition } from './useTransition/Transition.tsx';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     {/* <App /> */}
     {/* <SyntheticEvent /> */}
     {/* <Propagation /> */}
-    <UpdateState />
+    {/* <UpdateState /> */}
+    <Transition />
   </React.StrictMode>
 );

--- a/src/useTransition/Transition.tsx
+++ b/src/useTransition/Transition.tsx
@@ -1,0 +1,54 @@
+import { useState, useTransition } from 'react';
+
+type Tab = 'about' | 'post' | 'contact';
+
+export const Transition = () => {
+  const [isPending, startTransition] = useTransition();
+  const [tab, setTab] = useState<Tab>('about');
+
+  const handleSelectTab = (nextTab: Tab) => () => {
+    startTransition(() => {
+      setTab(nextTab);
+    });
+    // setTab(nextTab);
+  };
+
+  return (
+    <>
+      <button onClick={handleSelectTab('about')}>ABOUT</button>
+      <button onClick={handleSelectTab('post')}>POST</button>
+      <button onClick={handleSelectTab('contact')}>CONTACT</button>
+      {isPending && '로딩중!!'}
+      {tab === 'about' && <About />}
+      {tab === 'post' && <Post />}
+      {tab === 'contact' && <Contact />}
+    </>
+  );
+};
+
+export const About = () => {
+  return <h1>About</h1>;
+};
+
+// 무거운 연산이 포함된 컴포넌트
+export const Post = () => {
+  const items = Array.from({ length: 1500 }).map((_, i) => (
+    <Slow
+      key={i}
+      index={i}
+    />
+  ));
+
+  return <ul>{items}</ul>;
+};
+
+const Slow = ({ index }: { index: number }) => {
+  let startTime = performance.now();
+  while (performance.now() - startTime < 1) {}
+
+  return <li># ${index + 1}</li>;
+};
+
+export const Contact = () => {
+  return <h1>Contact</h1>;
+};


### PR DESCRIPTION
useTransition을 사용하면 무거운 렌더링 작업을 해야 하는 상태 업데이트를 지연시켜줄 수 있다.
무거운 렌더링을 하다가 `중단`하고 넘어가는 것이 가능하다는 점에서 이점을 받아들였지만,
상태를 분리하거나 분기처리가 필요할 것 같다. 같이 물려있는 상태까지 지연이 되어 예상과 다르게 동작했다.

지연이 예상되는 특정 상태를 업데이트해야 할 때만 startTransition을 사용하여 의도한 바를 구현할 수 있었다.

### useTransition 쓰기 전

https://github.com/user-attachments/assets/c1d11ff7-b36a-4428-8c8c-d29835ba5f38

### useTransition 사용 (처리 전)

https://github.com/user-attachments/assets/ac325470-02ee-4351-a9bc-ed4fba3435f3

### useTransition 사용 (처리 후)

https://github.com/user-attachments/assets/005f2ddd-a31f-4bac-9181-43a3f5a9fd90




