### PR TITLE
NamedExports, NamespaceExports - DisplayName plugin

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
   env: { browser: true, es2020: true },
-  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:react-hooks/recommended'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'plugin:react-hooks/recommended', 'plugin:storybook/recommended'],
   ignorePatterns: ['dist', '.eslintrc.cjs'],
   parser: '@typescript-eslint/parser',
   plugins: ['react-refresh'],

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+*storybook.log

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,16 @@
+import type { StorybookConfig } from "@storybook/react-vite";
+
+const config: StorybookConfig = {
+  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+  addons: [
+    "@storybook/addon-onboarding",
+    "@storybook/addon-essentials",
+    "@chromatic-com/storybook",
+    "@storybook/addon-interactions",
+  ],
+  framework: {
+    name: "@storybook/react-vite",
+    options: {},
+  },
+};
+export default config;

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,16 +1,27 @@
-import type { StorybookConfig } from "@storybook/react-vite";
+import type { StorybookConfig } from '@storybook/react-vite';
+import { InlineConfig } from 'vite';
+import { componentDisplayName } from '../src/namespace-exports-displayName/storybook-utils/componentDisplayName';
+import { tsMorphAddDisplayName } from '../src/namespace-exports-displayName/storybook-utils/tsMorphAddDisplayName';
+
+const TEST_DIRECTORY = '**/src/namespace-exports-displayName/index.ts';
+
+const viteFinal: StorybookConfig['viteFinal'] = (config: InlineConfig) => {
+  config.plugins?.push(tsMorphAddDisplayName([TEST_DIRECTORY]));
+  return config;
+};
 
 const config: StorybookConfig = {
-  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: [
-    "@storybook/addon-onboarding",
-    "@storybook/addon-essentials",
-    "@chromatic-com/storybook",
-    "@storybook/addon-interactions",
+    '@storybook/addon-onboarding',
+    '@storybook/addon-essentials',
+    '@chromatic-com/storybook',
+    '@storybook/addon-interactions',
   ],
   framework: {
-    name: "@storybook/react-vite",
+    name: '@storybook/react-vite',
     options: {},
   },
+  viteFinal,
 };
 export default config;

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,6 +1,6 @@
 import type { StorybookConfig } from '@storybook/react-vite';
 import { InlineConfig } from 'vite';
-import { componentDisplayName } from '../src/namespace-exports-displayName/storybook-utils/componentDisplayName';
+// import { componentDisplayName } from '../src/namespace-exports-displayName/storybook-utils/componentDisplayName';
 import { tsMorphAddDisplayName } from '../src/namespace-exports-displayName/storybook-utils/tsMorphAddDisplayName';
 
 const TEST_DIRECTORY = '**/src/namespace-exports-displayName/index.ts';

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,0 +1,14 @@
+import type { Preview } from "@storybook/react";
+
+const preview: Preview = {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "test": "jest"
+    "test": "jest",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
   },
   "resolutions": {
     "@radix-ui/react-dialog": "1.1.1"
@@ -33,6 +35,14 @@
     "vaul": "^1.1.2"
   },
   "devDependencies": {
+    "@chromatic-com/storybook": "^3.2.4",
+    "@storybook/addon-essentials": "8.6.0-alpha.1",
+    "@storybook/addon-interactions": "8.6.0-alpha.1",
+    "@storybook/addon-onboarding": "8.6.0-alpha.1",
+    "@storybook/blocks": "8.6.0-alpha.1",
+    "@storybook/react": "8.6.0-alpha.1",
+    "@storybook/react-vite": "8.6.0-alpha.1",
+    "@storybook/test": "8.6.0-alpha.1",
     "@tanstack/react-query-devtools": "^5.59.11",
     "@types/jest": "^29.5.13",
     "@types/react": "^18.2.15",
@@ -44,9 +54,11 @@
     "eslint": "^8.45.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",
+    "eslint-plugin-storybook": "^0.11.2",
     "jest": "^29.7.0",
     "postcss": "^8.5.1",
     "tailwindcss": "^3.4.0",
+    "storybook": "8.6.0-alpha.1",
     "typescript": "^5.0.2",
     "vite": "^4.4.5"
   }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@storybook/react-vite": "8.6.0-alpha.1",
     "@storybook/test": "8.6.0-alpha.1",
     "@tanstack/react-query-devtools": "^5.59.11",
+    "@types/glob-to-regexp": "^0.4.4",
     "@types/jest": "^29.5.13",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
@@ -55,10 +56,12 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",
     "eslint-plugin-storybook": "^0.11.2",
+    "glob-to-regexp": "^0.4.1",
     "jest": "^29.7.0",
     "postcss": "^8.5.1",
     "tailwindcss": "^3.4.0",
     "storybook": "8.6.0-alpha.1",
+    "ts-morph": "^25.0.0",
     "typescript": "^5.0.2",
     "vite": "^4.4.5"
   }

--- a/src/namespace-exports-displayName/NamespaceExports.stories.tsx
+++ b/src/namespace-exports-displayName/NamespaceExports.stories.tsx
@@ -1,4 +1,5 @@
 import { ObjectTemp, Temp } from '.';
+// import { withNamespaceDisplayName } from '@/namespace-exports-displayName/storybook-utils/withNamespaceDisplayName';
 
 export default {
   title: 'NamespaceExports',
@@ -7,6 +8,18 @@ export default {
 console.log('@@ storybook ->', {
   namespace: Temp,
   object: ObjectTemp,
+});
+
+console.log('@@ namespace - displayName !!');
+// const _Temp = withNamespaceDisplayName(Temp, 'Temp'); // <- tsMorphAddDisplayName 플러그인을 통해 처리
+Object.keys(Temp).forEach((key) => {
+  console.log(Temp[key as keyof typeof Temp].displayName); // Temp.Foo, Temp.Bar
+});
+
+console.log('--------------');
+console.log('@@ object - displayName !!');
+Object.keys(ObjectTemp).forEach((key) => {
+  console.log(ObjectTemp[key as keyof typeof ObjectTemp].displayName);
 });
 
 export const NamespaceExample = () => {

--- a/src/namespace-exports-displayName/NamespaceExports.stories.tsx
+++ b/src/namespace-exports-displayName/NamespaceExports.stories.tsx
@@ -1,0 +1,28 @@
+import { ObjectTemp, Temp } from '.';
+
+export default {
+  title: 'NamespaceExports',
+};
+
+console.log('@@ storybook ->', {
+  namespace: Temp,
+  object: ObjectTemp,
+});
+
+export const NamespaceExample = () => {
+  return (
+    <div>
+      <Temp.Foo />
+      <Temp.Bar />
+    </div>
+  );
+};
+
+export const ObjectExample = () => {
+  return (
+    <div>
+      <ObjectTemp.Foo />
+      <ObjectTemp.Bar />
+    </div>
+  );
+};

--- a/src/namespace-exports-displayName/components/Bar.tsx
+++ b/src/namespace-exports-displayName/components/Bar.tsx
@@ -1,0 +1,17 @@
+import { forwardRef } from 'react';
+
+interface BarProps {
+  name?: string;
+  age?: number;
+}
+
+export const TestBar = forwardRef<HTMLDivElement, BarProps>((props, ref) => {
+  const { name = 'bar', age = 20 } = props;
+
+  return (
+    <div ref={ref}>
+      <h1>{name}</h1>
+      <h2>{age}</h2>
+    </div>
+  );
+});

--- a/src/namespace-exports-displayName/components/Foo.tsx
+++ b/src/namespace-exports-displayName/components/Foo.tsx
@@ -1,0 +1,17 @@
+import { forwardRef } from 'react';
+
+interface FooProps {
+  name?: string;
+  age?: number;
+}
+
+export const TestFoo = forwardRef<HTMLDivElement, FooProps>((props, ref) => {
+  const { name = 'foo', age = 10 } = props;
+
+  return (
+    <div ref={ref}>
+      <h1>{name}</h1>
+      <h2>{age}</h2>
+    </div>
+  );
+});

--- a/src/namespace-exports-displayName/components/ObjectTemp.ts
+++ b/src/namespace-exports-displayName/components/ObjectTemp.ts
@@ -1,0 +1,8 @@
+import { TestBar } from './Bar';
+import { TestFoo } from './Foo';
+
+export type ObjectTempProps = 'a' | 'b' | 'c';
+export const ObjectTemp = {
+  Foo: TestFoo,
+  Bar: TestBar,
+};

--- a/src/namespace-exports-displayName/components/index.ts
+++ b/src/namespace-exports-displayName/components/index.ts
@@ -1,0 +1,2 @@
+export { TestFoo as Foo } from './Foo';
+export { TestBar as Bar } from './Bar';

--- a/src/namespace-exports-displayName/index.ts
+++ b/src/namespace-exports-displayName/index.ts
@@ -1,8 +1,3 @@
-import { TestBar } from './components/Bar';
-import { TestFoo } from './components/Foo';
-
 export * as Temp from './components';
-export const ObjectTemp = {
-  Foo: TestFoo,
-  Bar: TestBar,
-};
+export { ObjectTemp } from './components/ObjectTemp';
+export type { ObjectTempProps } from './components/ObjectTemp';

--- a/src/namespace-exports-displayName/index.ts
+++ b/src/namespace-exports-displayName/index.ts
@@ -1,0 +1,8 @@
+import { TestBar } from './components/Bar';
+import { TestFoo } from './components/Foo';
+
+export * as Temp from './components';
+export const ObjectTemp = {
+  Foo: TestFoo,
+  Bar: TestBar,
+};

--- a/src/namespace-exports-displayName/storybook-utils/componentDisplayName.ts
+++ b/src/namespace-exports-displayName/storybook-utils/componentDisplayName.ts
@@ -1,0 +1,26 @@
+import type { PluginOption } from 'vite';
+import globToRegExp from 'glob-to-regexp';
+
+export const componentDisplayName = (globPatterns: Array<string>): PluginOption => {
+  return {
+    name: 'component-displayName',
+    /**
+     * @param code 현재 변환 중인 파일의 소스 코드(텍스트 형태)
+     * @param id 현재 변환 중인 모듈의 파일 경로나 ID
+     * @param options 플러그인이 호출되는 현재 상황에 대한 추가 정보. 예를 들어 ssr 여부
+     */
+    transform(code, id) {
+      // NOTE: 모든 파일의 소스코드가 들어오게 되는데, 지정한 globPatterns에 해당하는 파일만 거르기 위함
+      const regexps = globPatterns.map((pattern) => new RegExp(globToRegExp(pattern)));
+      const isPassed = regexps.some((regexp) => regexp.test(id));
+
+      if (!isPassed) return code;
+
+      // NOTE: 소스 코드를 변형하는 것이 가능
+      return `
+      ${code}
+      // 소스 코드 자체를 변형할 수 있다.
+      `;
+    },
+  };
+};

--- a/src/namespace-exports-displayName/storybook-utils/tsMorphAddDisplayName.ts
+++ b/src/namespace-exports-displayName/storybook-utils/tsMorphAddDisplayName.ts
@@ -17,11 +17,15 @@ export const tsMorphAddDisplayName = (globPatterns: Array<string>): PluginOption
       // sourceFile.getExportDeclarations().length: 2
       sourceFile.getExportDeclarations().forEach((exportDeclaration) => {
         const namespaceExport = exportDeclaration.getNamespaceExport(); // 네임스페이스 가져오기
-        const moduleSpecifier = exportDeclaration.getModuleSpecifier() as unknown as string; // 모듈 경로
+        const moduleSpecifier = exportDeclaration.getModuleSpecifier()?.getLiteralValue() ?? ''; // 모듈 경로 가져오기
         const isNamespaceExport = namespaceExport != null;
 
         if (isNamespaceExport) {
           const nameSpaceName = namespaceExport.getName();
+          /**
+           * import * as _Temp from './components'; 을 추가한다.
+           * 이렇게 하면 _Temp 모듈 자체를 읽을 수 있다.
+           */
           sourceFile.addImportDeclaration({
             moduleSpecifier,
             namespaceImport: `_${nameSpaceName}`,
@@ -29,55 +33,21 @@ export const tsMorphAddDisplayName = (globPatterns: Array<string>): PluginOption
 
           sourceFile.insertStatements(
             0,
-            `import { namespaceExportOverrideDisplayName } from '@/namespace-exports-disaplyName/storybook-utils'`
+            `import { withNamespaceDisplayName } from '@/namespace-exports-displayName/storybook-utils/withNamespaceDisplayName';`
           );
 
           sourceFile.addStatements([
-            `const ${nameSpaceName} = namespaceExportOverrideDisplayName({ Module: _${nameSpaceName}, displayName: '${nameSpaceName}' })`,
+            `const ${nameSpaceName} = withNamespaceDisplayName(_${nameSpaceName}, '${nameSpaceName}')`,
             `export { ${nameSpaceName} }`,
           ]);
+
+          // export * as Temp from './components'; 을 제거
           exportDeclaration.remove();
         } else {
-          // namespace export가 아닌 export 목록을 가져온다 (타입은 포함 X)
-          const namedExports = exportDeclaration.getNamedExports(); // ex. ObjectTemp
-
-          /**
-           * as-is: export { ObjectTemp } from './components/ObjectTemp';
-           * to-be: export { ObjectTemp as _ObjectTemp } from './components/ObjectTemp';
-           */
-          sourceFile.addImportDeclaration({
-            moduleSpecifier,
-            namedImports: namedExports.map((namedExport) => ({
-              name: namedExport.getName(),
-              alias: `_${namedExport.getName()}`,
-            })),
-          });
-
-          namedExports.forEach((namedExport) => {
-            const name = namedExport.getName();
-            sourceFile.insertStatements(
-              0, // 파일 맨 앞에 삽입
-              `import { namedExportOverrideDisplayName } from '@/namespace-exports-disaplyName/storybook-utils'`
-            );
-            // 새로운 변수를 선언하고 `displayName`을 추가
-            sourceFile.addStatements([
-              `const ${name} = namedExportOverrideDisplayName({ Component: _${name}, displayName: '${name}' })`,
-              `export { ${name} }`,
-            ]);
-
-            /**
-             * import { namedExportOverrideDisplayName } from '@/namespace-exports-disaplyName/storybook-utils';
-             * import { Foo as _Foo, Bar as _Bar } from './components';
-             *
-             * const Foo = namedExportOverrideDisplayName({ Component: _Foo, displayName: 'Foo' });
-             * const Bar = namedExportOverrideDisplayName({ Component: _Bar, displayName: 'Bar' });
-             *
-             * export { Foo, Bar };
-             */
-            exportDeclaration.remove(); // 기존 export 문을 삭제해서 원본이 남지 않도록 처리
-          });
+          return code;
         }
       });
+      console.log('@@ fullText -> ', sourceFile.getFullText());
       return sourceFile.getFullText();
     },
   };

--- a/src/namespace-exports-displayName/storybook-utils/tsMorphAddDisplayName.ts
+++ b/src/namespace-exports-displayName/storybook-utils/tsMorphAddDisplayName.ts
@@ -1,0 +1,84 @@
+import { PluginOption } from 'vite';
+import globToRegExp from 'glob-to-regexp';
+import { Project } from 'ts-morph';
+
+export const tsMorphAddDisplayName = (globPatterns: Array<string>): PluginOption => {
+  const project = new Project();
+  return {
+    name: 'add-displayName-ts-morph',
+    transform(code, id) {
+      const regexps = globPatterns.map((pattern) => new RegExp(globToRegExp(pattern)));
+      const isPassed = regexps.some((regexp) => regexp.test(id));
+
+      if (!isPassed) return code;
+
+      const sourceFile = project.createSourceFile('__temporary__' + id, code);
+
+      // sourceFile.getExportDeclarations().length: 2
+      sourceFile.getExportDeclarations().forEach((exportDeclaration) => {
+        const namespaceExport = exportDeclaration.getNamespaceExport(); // 네임스페이스 가져오기
+        const moduleSpecifier = exportDeclaration.getModuleSpecifier() as unknown as string; // 모듈 경로
+        const isNamespaceExport = namespaceExport != null;
+
+        if (isNamespaceExport) {
+          const nameSpaceName = namespaceExport.getName();
+          sourceFile.addImportDeclaration({
+            moduleSpecifier,
+            namespaceImport: `_${nameSpaceName}`,
+          });
+
+          sourceFile.insertStatements(
+            0,
+            `import { namespaceExportOverrideDisplayName } from '@/namespace-exports-disaplyName/storybook-utils'`
+          );
+
+          sourceFile.addStatements([
+            `const ${nameSpaceName} = namespaceExportOverrideDisplayName({ Module: _${nameSpaceName}, displayName: '${nameSpaceName}' })`,
+            `export { ${nameSpaceName} }`,
+          ]);
+          exportDeclaration.remove();
+        } else {
+          // namespace export가 아닌 export 목록을 가져온다 (타입은 포함 X)
+          const namedExports = exportDeclaration.getNamedExports(); // ex. ObjectTemp
+
+          /**
+           * as-is: export { ObjectTemp } from './components/ObjectTemp';
+           * to-be: export { ObjectTemp as _ObjectTemp } from './components/ObjectTemp';
+           */
+          sourceFile.addImportDeclaration({
+            moduleSpecifier,
+            namedImports: namedExports.map((namedExport) => ({
+              name: namedExport.getName(),
+              alias: `_${namedExport.getName()}`,
+            })),
+          });
+
+          namedExports.forEach((namedExport) => {
+            const name = namedExport.getName();
+            sourceFile.insertStatements(
+              0, // 파일 맨 앞에 삽입
+              `import { namedExportOverrideDisplayName } from '@/namespace-exports-disaplyName/storybook-utils'`
+            );
+            // 새로운 변수를 선언하고 `displayName`을 추가
+            sourceFile.addStatements([
+              `const ${name} = namedExportOverrideDisplayName({ Component: _${name}, displayName: '${name}' })`,
+              `export { ${name} }`,
+            ]);
+
+            /**
+             * import { namedExportOverrideDisplayName } from '@/namespace-exports-disaplyName/storybook-utils';
+             * import { Foo as _Foo, Bar as _Bar } from './components';
+             *
+             * const Foo = namedExportOverrideDisplayName({ Component: _Foo, displayName: 'Foo' });
+             * const Bar = namedExportOverrideDisplayName({ Component: _Bar, displayName: 'Bar' });
+             *
+             * export { Foo, Bar };
+             */
+            exportDeclaration.remove(); // 기존 export 문을 삭제해서 원본이 남지 않도록 처리
+          });
+        }
+      });
+      return sourceFile.getFullText();
+    },
+  };
+};

--- a/src/namespace-exports-displayName/storybook-utils/withNamedDisplayName.ts
+++ b/src/namespace-exports-displayName/storybook-utils/withNamedDisplayName.ts
@@ -1,12 +1,9 @@
 export const withNamedDisplayName = (object: Record<string, any>, displayName: string) => {
-  (object as { displayName?: string }).displayName = displayName;
-
-  Object.keys(object).forEach((key) => {
-    const item = object[key];
-    if (typeof item === 'object' && 'displayName' in item) {
-      (item as { displayName?: string }).displayName = `${displayName}.${key}`;
-    }
-  });
-
-  return object;
+  if (typeof object !== 'object' || object === null) return object;
+  return Object.fromEntries(
+    Object.entries(object).map(([key, value]) => [
+      key,
+      value != null && typeof value === 'object' ? { ...value, displayName: `${displayName}.${key}` } : value,
+    ])
+  );
 };

--- a/src/namespace-exports-displayName/storybook-utils/withNamedDisplayName.ts
+++ b/src/namespace-exports-displayName/storybook-utils/withNamedDisplayName.ts
@@ -1,0 +1,12 @@
+export const withNamedDisplayName = (object: Record<string, any>, displayName: string) => {
+  (object as { displayName?: string }).displayName = displayName;
+
+  Object.keys(object).forEach((key) => {
+    const item = object[key];
+    if (typeof item === 'object' && 'displayName' in item) {
+      (item as { displayName?: string }).displayName = `${displayName}.${key}`;
+    }
+  });
+
+  return object;
+};

--- a/src/namespace-exports-displayName/storybook-utils/withNamespaceDisplayName.ts
+++ b/src/namespace-exports-displayName/storybook-utils/withNamespaceDisplayName.ts
@@ -1,0 +1,6 @@
+export const withNamespaceDisplayName = (module: Record<string, any>, displayName: string) => {
+  Object.keys(module).forEach((key) => {
+    module[key].displayName = `${displayName}.${key}`;
+  });
+  return module;
+};

--- a/src/namespace-exports-displayName/storybook-utils/withNamespaceDisplayName.ts
+++ b/src/namespace-exports-displayName/storybook-utils/withNamespaceDisplayName.ts
@@ -1,6 +1,8 @@
 export const withNamespaceDisplayName = (module: Record<string, any>, displayName: string) => {
-  Object.keys(module).forEach((key) => {
-    module[key].displayName = `${displayName}.${key}`;
-  });
-  return module;
+  return Object.fromEntries(
+    Object.entries(module).map(([key, value]) => [
+      key,
+      value != null && typeof value === 'object' ? { ...value, displayName: `${displayName}.${key}` } : value,
+    ])
+  );
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,16 +19,11 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }
   },
   "include": ["src"],
-  "references": [
-    {
-      "path": "./tsconfig.node.json"
-    }
-  ]
+  "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,10 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
-import path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
   resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-    },
+    alias: [{ find: '@', replacement: '/src' }],
   },
 });


### PR DESCRIPTION
## 🔎 상황

최근 회사에서 `NamespaceExports`로 내보내기가 된 모듈에 대해 `displayName`을 삽입하는 로직이 필요했다.

기존에도 plugin이 존재했지만, `NamedExports`로 내보내기 될 때 평가가 가능해서 바로 displayName 삽입이 가능했지만, `NamespaceExports`의 경우 `export * as Temp from './Temp'` 시점에는 모듈로 평가되지 않아 호환되지 못했다. (구조도 변경되기도 했다)

## 🐢 문제

`NameSpaceExports`로 내보내기가 된 모듈을 읽어오는 것부터 문제가 많았다.

### export하는 파일에서는 아직 모듈이 아니다

대강 흐름을 설명해보자면

1. `index.ts` 파일을 읽어온다
2. 여기서 `export * as` 다음으로 오는 네임스페이스 이름을 읽어온다.
3. 읽어온 파일에서 이 이름을 가지고 ... (이 다음부터 불가능했다)

`NamespaceExports`한 모듈은 `import`를 해올 때 모듈로 평가가 되기 때문에 해당 파일에서는 네임스페이스 이름으로 읽는 것부터가 불가능했다.

## 🏃 액션

> 결국 내가 해결하진 못하고 다른 분께 업무가 넘어갔는데 해결되어 그 과정을 알아보려고 한다.

### ts-morph 활용하기

> TypeScript 코드와 프로젝트를 동적으로 분석하고, 변환하거나 생성할 수 있도록 돕는 라이브러리

코드에는 [ts-morph](https://ts-morph.com/) 라이브러리를 통해 모듈을 읽거나 특정 라인을 삽입한다거나 하는 조작을 위한 API를 사용하고 있었다.

직접 확인해본 결과 파일에서 `getExportDeclarations`로 export된 `NamespaceExport`나 `NamedExport`를 모두 API를 통해 간편하게 읽어올 수 있었다.

### 참조값이 동일하게 오버라이드되는 문제 해결하기

ts-morph를 통해 간편하게 읽어오고 삽입하는 API를 통해 원했던 대로 `NamespaceExport`와 `NamedExport` 두 종류에서 모두 `displayName`을 삽입하는 것을 마쳤는데, 문제가 있다.

보통 컴파운드 컴포넌트들은 참조값을 유지하면서 서브 컴포넌트로 바로 re-export하는 경우가 많은데, 이럴 때 참조값이 바뀌지 않은 채`displayName`이 삽입되기 때문에 계속해서 오버라이드되는 문제를 발견하게 되었다. 

서브 컴포넌트를 순회하며 `displayName`을 삽입할 때 참조값을 깰 수 있도록 spread 연산자를 사용해주었다.

## 🎉 결과

<img src="https://github.com/user-attachments/assets/dd3abb42-ace7-4b51-aea9-dbdf47aee4aa" width="500" />

