### PR TITLE
같은 key prop을 사용하면 생기는 기묘한 일

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import './index.css';
 // import { SingletonTest } from './singleton/axios-example/Test';
 // import { ReflowTrigger } from './reflow-trigger/ReflowTrigger';
 import { SameKeyProp } from './same-key-prop/SameKeyProp';
+// import { ReactElement } from './same-key-prop/ReactElement';
 // import { UseOverlayExample } from './overlay/useOverlay/UseOverlay';
 // import { FlushSync } from './flushSync/FlushSync';
 // import { SyntheticEvent } from './SyntheticEvent/index.tsx';
@@ -27,5 +28,6 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     {/* <SingletonTest /> */}
     {/* <ReflowTrigger /> */}
     <SameKeyProp />
+    {/* <ReactElement /> */}
   </>
 );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,8 @@ import './index.css';
 // import { VirtualDom } from './virtual-dom/VirtualDom';
 // import { BottomSheetTest } from './bottom-sheet/BottomSheetTest';
 // import { SingletonTest } from './singleton/axios-example/Test';
-import { ReflowTrigger } from './reflow-trigger/ReflowTrigger';
+// import { ReflowTrigger } from './reflow-trigger/ReflowTrigger';
+import { SameKeyProp } from './same-key-prop/SameKeyProp';
 // import { UseOverlayExample } from './overlay/useOverlay/UseOverlay';
 // import { FlushSync } from './flushSync/FlushSync';
 // import { SyntheticEvent } from './SyntheticEvent/index.tsx';
@@ -24,6 +25,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     {/* <VirtualDom /> */}
     {/* <BottomSheetTest /> */}
     {/* <SingletonTest /> */}
-    <ReflowTrigger />
+    {/* <ReflowTrigger /> */}
+    <SameKeyProp />
   </>
 );

--- a/src/same-key-prop/ReactElement.tsx
+++ b/src/same-key-prop/ReactElement.tsx
@@ -1,0 +1,74 @@
+import { createElement, isValidElement } from 'react';
+
+const testArr = Array.from({ length: 10 }, (_, i) => `${i + 1}번째 아이템`);
+
+export const ReactElement = () => {
+  /**
+   * @NOTE
+   * isValidElement는 인자가 JSX 요소라면 true를 반환한다.
+   * 즉, 리액트 컴포넌트 -> createElement로 변환되어 호출 -> 이때 JSX 요소인가?
+   */
+  console.log(isValidElement(<SomethingRenderString />)); // true
+  console.log(isValidElement(<SomethingRenderHTML />)); // true
+  console.log(isValidElement(somethingRenderHTML())); // true
+  console.log(<SomethingRenderString />);
+  /**
+   * @NOTE
+   * createElement(SomethingRenderHTML, null)
+   * => SomethingRenderHTML 자체가 실행된 것이 아니라 React가 렌더링할 준비를 한 상태이다.
+   *
+   * 💡 즉, < />로 쓰는 것이 컴포넌트(함수)를 호출한 것이 아니다.
+   */
+  console.log(<SomethingRenderHTML />);
+  /**
+   * @NOTE
+   * 이건 호출되어 반환된 결과가 변환된 것
+   * => createElement("div", null, ...)
+   */
+  console.log(somethingRenderHTML());
+
+  /**
+   * @NOTE
+   * 바로 호출하는 형태도 key prop warning이 뜬다. 반환하는 JSX에 key prop이 없기 때문이다.
+   */
+  // return testArr.map((item) => somethingRenderHTML(item));
+
+  return null;
+};
+
+/**
+ * @NOTE 꺽쇠와 대문자로 쓴다고 다 리액트 엘리먼트로 평가되는 건 아니다.
+ * 'SomethingConsole'은(는) JSX 구성 요소로 사용할 수 없습니다.
+ *   해당 '() => void' 형식은 올바른 JSX 요소 형식이 아닙니다.
+ *
+ * 이건 애초부터 <SomethingConsole />로 사용하려면 타입 에러가 난다.
+ * 리액트 컴포넌트는 ReactNode를 반환해야 한다. 즉, 이건 void를 리턴하고 있어 JSX 요소가 될 수 없다.
+ *
+ * 💡 리액트 컴포넌트와 JSX 요소
+ * - 리액트 컴포넌트: const Component = () => <div />
+ * - JSX 요소: <Component />를 실행 후 생성되는 객체 즉, React.createElement로 변환된 객체
+ */
+const SomethingConsole = () => {
+  console.log('이건 아무것도 반환하지 않고..');
+};
+
+/**
+ * () => JSX.Element
+ */
+const SomethingRenderHTML = () => {
+  return <div />;
+};
+
+/**
+ * @NOTE
+ * 리액트 컴포넌트는 ReactNode를 반환해야 한다. string은 ReactNode에 포함되기 때문에 일단 리액트 컴포넌트가 되는 것은 가능하다.
+ *
+ * 💡 ReactNode는 React가 렌더링할 수 있는 모든 값을 포함하는 타입
+ */
+const SomethingRenderString = () => {
+  return 'string';
+};
+
+const somethingRenderHTML = (text?: string) => {
+  return <div>{text}</div>;
+};

--- a/src/same-key-prop/SameKeyProp.tsx
+++ b/src/same-key-prop/SameKeyProp.tsx
@@ -1,0 +1,84 @@
+import { ReactElement, useState } from 'react';
+
+type Colors = 'red' | 'blue' | 'green' | 'orange';
+
+export const SameKeyProp = () => {
+  const [items, setItems] = useState<Colors[]>([]);
+
+  return (
+    <div style={{ display: 'flex', width: '100vw', height: '100vh' }}>
+      {/* 캔버스 역할 */}
+      <section style={{ flex: 1 }}>
+        {items.map((color) => (
+          <SwitchCase
+            key={color}
+            value={color}
+            caseBy={{
+              red: (
+                <div style={{ width: '150px', height: '150px', backgroundColor: 'red', color: 'white' }}>
+                  저는 Red인데요, 150px이에요
+                </div>
+              ),
+              blue: (
+                <div style={{ width: '80px', height: '80px', backgroundColor: 'blue', color: 'white' }}>
+                  저는 Blue인데요, 80px이에요
+                </div>
+              ),
+              green: (
+                <div style={{ width: '100px', height: '100px', backgroundColor: 'green' }}>
+                  저는 Green인데요, 100px이에요
+                </div>
+              ),
+              orange: (
+                <div style={{ width: '200px', height: '200px', backgroundColor: 'orange' }}>
+                  저는 Orange인데요, 200px이에요
+                </div>
+              ),
+            }}
+          />
+        ))}
+      </section>
+
+      {/* 패널 역할 */}
+      <section style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+        <div style={{ display: 'flex', gap: '20px' }}>
+          <button onClick={() => setItems((prev) => [...prev, 'red'])}>컬러 블록 추가하기 +1</button>
+          <button onClick={() => setItems((prev) => prev.slice(0, -1))}>컬러 블록 추가하기 빼기 -1</button>
+        </div>
+
+        <div>{`items: [${items.join(', ')}]`}</div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '10px', marginTop: '20px' }}>
+          {items.map((_, index) => (
+            <select
+              key={index}
+              name={`${index + 1}번째 컬러 선택`}
+              value={items[index]}
+              onChange={(e) => {
+                const selectedColor = e.target.value as Colors;
+                setItems((prev) => prev.map((color, i) => (i === index ? selectedColor : color)));
+              }}
+              style={{ border: '1px solid grey', padding: '8px', borderRadius: '8px', width: '200px' }}>
+              <option value='red'>red</option>
+              <option value='blue'>blue</option>
+              <option value='green'>green</option>
+              <option value='orange'>orange</option>
+            </select>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+interface SwitchCaseProps<T extends string | number> {
+  caseBy: Partial<Record<T, ReactElement | null>>;
+  value: T;
+  defaultComponent?: ReactElement | null;
+}
+const SwitchCase = <T extends string | number>({ value, caseBy, defaultComponent }: SwitchCaseProps<T>) => {
+  if (value == null) {
+    return defaultComponent;
+  }
+  return caseBy[value] ?? defaultComponent;
+};

--- a/src/same-key-prop/SameKeyProp.tsx
+++ b/src/same-key-prop/SameKeyProp.tsx
@@ -1,42 +1,47 @@
-import { ReactElement, useState } from 'react';
+import { ReactNode, useState } from 'react';
 
 type Colors = 'red' | 'blue' | 'green' | 'orange';
 
 export const SameKeyProp = () => {
   const [items, setItems] = useState<Colors[]>([]);
+  const [number, setNumber] = useState(0);
 
   return (
     <div style={{ display: 'flex', width: '100vw', height: '100vh' }}>
       {/* 캔버스 역할 */}
+      {/* 렌더링을 트리거해도 동기화되지 않는다. */}
+      <button onClick={() => setNumber((prev) => prev + 1)}>이걸로 렌더링을 트리거해보자</button>
       <section style={{ flex: 1 }}>
-        {items.map((color) => (
-          <SwitchCase
-            key={color}
-            value={color}
-            caseBy={{
-              red: (
-                <div style={{ width: '150px', height: '150px', backgroundColor: 'red', color: 'white' }}>
-                  저는 Red인데요, 150px이에요
-                </div>
-              ),
-              blue: (
-                <div style={{ width: '80px', height: '80px', backgroundColor: 'blue', color: 'white' }}>
-                  저는 Blue인데요, 80px이에요
-                </div>
-              ),
-              green: (
-                <div style={{ width: '100px', height: '100px', backgroundColor: 'green' }}>
-                  저는 Green인데요, 100px이에요
-                </div>
-              ),
-              orange: (
-                <div style={{ width: '200px', height: '200px', backgroundColor: 'orange' }}>
-                  저는 Orange인데요, 200px이에요
-                </div>
-              ),
-            }}
-          />
-        ))}
+        {items.map((color) => {
+          /**
+           * @NOTE
+           * SwitchCase만으로도 리액트 엘리먼트로 평가되었다.
+           */
+          console.log(
+            <SwitchCase
+              key={color}
+              value={color}
+              caseBy={{
+                red: <div style={{ width: '150px', height: '150px', backgroundColor: 'red', color: 'white' }}>저는 Red인데요, 150px이에요</div>,
+                blue: <div style={{ width: '80px', height: '80px', backgroundColor: 'blue', color: 'white' }}>저는 Blue인데요, 80px이에요</div>,
+                green: <div style={{ width: '100px', height: '100px', backgroundColor: 'green' }}>저는 Green인데요, 100px이에요</div>,
+                orange: <div style={{ width: '200px', height: '200px', backgroundColor: 'orange' }}>저는 Orange인데요, 200px이에요</div>,
+              }}
+            />
+          );
+          return (
+            <SwitchCase
+              key={color}
+              value={color}
+              caseBy={{
+                red: <div style={{ width: '150px', height: '150px', backgroundColor: 'red', color: 'white' }}>저는 Red인데요, 150px이에요</div>,
+                blue: <div style={{ width: '80px', height: '80px', backgroundColor: 'blue', color: 'white' }}>저는 Blue인데요, 80px이에요</div>,
+                green: <div style={{ width: '100px', height: '100px', backgroundColor: 'green' }}>저는 Green인데요, 100px이에요</div>,
+                orange: <div style={{ width: '200px', height: '200px', backgroundColor: 'orange' }}>저는 Orange인데요, 200px이에요</div>,
+              }}
+            />
+          );
+        })}
       </section>
 
       {/* 패널 역할 */}
@@ -72,9 +77,9 @@ export const SameKeyProp = () => {
 };
 
 interface SwitchCaseProps<T extends string | number> {
-  caseBy: Partial<Record<T, ReactElement | null>>;
+  caseBy: Partial<Record<T, ReactNode | null>>;
   value: T;
-  defaultComponent?: ReactElement | null;
+  defaultComponent?: ReactNode | null;
 }
 const SwitchCase = <T extends string | number>({ value, caseBy, defaultComponent }: SwitchCaseProps<T>) => {
   if (value == null) {


### PR DESCRIPTION
## 🔎 상황

최근 회사에서 값을 바꿔도 **기존에 선택했던 값이 남아있다는 제보**를 받게 되었다. 재현을 해보았는데, 상태와는 무관하게 렌더링 되는 아이템이 증식(?) 되는 기묘한 현상을 발견하게 되었다.

https://github.com/user-attachments/assets/fc06898c-9634-49df-8488-4cfa3bdada99

## 🐢 문제

원인이 무엇일까.. 디버깅 하다가

- children으로 들어가는 옵션을 +1, +1 하면서 추가 가능하고
- 추가 후 셀렉트를 통해 컴포넌트 종류를 선택 가능하다. 이때 값은 `option_type`이며
- SwitchCase를 사용하였고, SwitchCase의 `key` prop으로 `option_type`을 넣고 있었다.
- 이때, children으로는 `버튼` `버튼` 처럼 동일한 종류의 컴포넌트가 들어갈 수 있기 때문에
- 중복되는 `key` prop이 들어갈 수 있는 상황인 것이다.

어쨌든 `${index}-${option_type}`으로 중복되지 않게 처리해서 쉽게 해결 가능했으나 궁금한 점이 생겼다.

1. `<SwitchCase/>` 컴포넌트에 `key` prop을 전달한다는 건 어떻게 활용된다는 걸까? 구조적으로 궁금
2. `key` prop은 효율적인 재조정을 위해 고유한 값을 넣어야 한다는 건 대강 알고 있는데, 정확히 뭐 때문에 저 기묘한 현상이 벌어진걸까?

## 🏃 액션

### 콘솔 탭에서

https://github.com/user-attachments/assets/1a081e40-29a8-4843-b9d9-9dc39818e666

로그를 확인해보았을 때, key값이 중복될 경우 가장 마지막에 있는 엘리먼트만 살려놓고 **나머지는 관리하지 않게 되는 것** 같았다.

<br />


### React가 중복된 key prop을 처리하는 방식으로부터 증식되는 현상의 원인을 찾아보자

```
TL;DR
- 이전 childrenArray를 map 자료구조로 관리한다
- 그래서 동일한 key를 가진 리액트 엘리먼트가 있다면, 마지막만 남게된다
- 따라서 이외의 것은 덮어씌워지게 되면서 react가 더 이상 참조하지 않게 된다
- 그래서 DOM 상에는 계속 보이지만 react로는 다룰 수 없게 된 것
```

[여기](https://github.com/facebook/react/blob/main/packages/react-reconciler/src/ReactChildFiber.js#L1111)서 어떻게 수행하는지 알 수가 있는데 [updateFromMap](https://github.com/facebook/react/blob/main/packages/react-reconciler/src/ReactChildFiber.js#L1247)을 호출하는 곳을 봐야한다.

위 영상 기준으로 따라가보면

1. [existingChildren이라는 map](https://github.com/facebook/react/blob/main/packages/react-reconciler/src/ReactChildFiber.js#L1242-L1243)에 oldFiber 즉, `{ key: 'red' }, { key: 'red' }` 이렇게 중복된 key를 가진 객체 2개가 담는다고 한다면, 같은 key이기 때문에 마지막 Fiber로 덮어씌우게 된다
2. `{ key: 'blue' }, { key: 'red' }`로 update를 시도한다고 해보자
3. [map에 이미 존재하는지 확인한다](https://github.com/facebook/react/blob/main/packages/react-reconciler/src/ReactChildFiber.js#L928)
4. `blue`는 없으니 [새로 추가](https://github.com/facebook/react/blob/main/packages/react-reconciler/src/ReactChildFiber.js#L566-L574)한다
5. 그 다음 `red`에 대해서는 map에 존재한다
6. 결론적으로는 `{ key: red (map에 의해 덮어씌워진, react가 더이상 참조하지 않는) }, { key: 'blue' }, { key: 'red' }`가 된 것이다

--> 💡 map에 의해 덮어씌워진 후에는 react가 더이상 참조하지 않는 Fiber 노드가 되어 DOM에 남아 있을 수 있다.

<br />

### SwitchCase도 리액트 컴포넌트다

```
TL;DR
- ReactNode를 반환하면, 결론적으로는 리액트 컴포넌트다
```

`<SwitchCase />` 같은 경우에도 `caseBy`에서 `ReactNode | null`을 받을 수 있도록 했기 때문에 리액트 컴포넌트가 될 수 있었다.

<img src="https://github.com/user-attachments/assets/a9fec0ff-b501-4155-b5c4-c554175f956c" width="500" />

`SwitchCase` 자체가 리액트 컴포넌트임을 알고 나니 `key` prop을 전달했을 때 어디로 흘러가 사용된다는 것이 아니라, 해당 컴포넌트 자체에서 식별자로 활용된다는 것을 이해할 수 있었다.

<br />

### switchCase였다면 key prop은 어떻게 될까

```
TL;DR
- 반환된 리액트 엘리먼트에 key prop이 없다면 똑같이 warning이 발생한다.
```

사실 리액트 컴포넌트도 함수긴 함수다.

```tsx
const RenderSomething = () => {
  return <div />
}

const renderSomething = () => {
  return <div />
}

console.log(<RenderSomething />) // 1️⃣
console.log(renderSomething()) // 2️⃣
```

- 1️⃣ 은 RenderSomething가 호출된 것이 아니다. 트랜스파일러에 의해 리액트 컴포넌트는 `React.createElement(RenderSomething, null)`로 변환되게 되는데 이때 React 엘리먼트가 생성될 뿐, RenderSomething 함수는 아직 실행되지 않았다. 
   
   - 이 엘리먼트는 type이 RenderSomething인 객체이며, 아직 RenderSomething 함수가 실행된 것은 아니다.

- 2️⃣ 는 호출되었다. 즉, return되었다. `<div />`가 `React.createElement("div", null, ...)`가 되어 React 엘리먼트로 변환된 것이다.


그래서 아래와 같이 결과물이 다르긴 하지만, **결론적으로는 둘 다 리액트 엘리먼트를 반환**한다. 그래서 둘 중 뭐가 되었든 변환된 객체에 `key` prop이 없다면 warning이 발생하는 것이다.

<img src="https://github.com/user-attachments/assets/2a82ea23-850c-4d1a-9069-c242c1e79d6c" width="500" />


## 🎉 결과

`key` prop이 어떻게 활용되는지를 아니까 모든 게 다 이해되었고 재밌었다. 그리고 평소에 얼핏 알고 넘어갔었던 ReactNode, ReactElement, JSX.Element 그리고 어떤 게 리액트 컴포넌트가 될 수 있는 것들인가를 한번 싹 정리하고 넘어오니까 일상 생활에서도 좀 더 코드가 잘 보이고 있다 0_0