### PR TITLE
offsetWidth는 항상 리플로우를 트리거하지는 않는다

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,8 @@ import './index.css';
 // import { CleanUpFunction } from './clean-up-function/CleanUpFunction';
 // import { VirtualDom } from './virtual-dom/VirtualDom';
 // import { BottomSheetTest } from './bottom-sheet/BottomSheetTest';
-import { SingletonTest } from './singleton/axios-example/Test';
+// import { SingletonTest } from './singleton/axios-example/Test';
+import { ReflowTrigger } from './reflow-trigger/ReflowTrigger';
 // import { UseOverlayExample } from './overlay/useOverlay/UseOverlay';
 // import { FlushSync } from './flushSync/FlushSync';
 // import { SyntheticEvent } from './SyntheticEvent/index.tsx';
@@ -22,6 +23,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     {/* <CleanUpFunction /> */}
     {/* <VirtualDom /> */}
     {/* <BottomSheetTest /> */}
-    <SingletonTest />
+    {/* <SingletonTest /> */}
+    <ReflowTrigger />
   </>
 );

--- a/src/reflow-trigger/ReflowTrigger.tsx
+++ b/src/reflow-trigger/ReflowTrigger.tsx
@@ -1,0 +1,43 @@
+import { useRef } from 'react';
+
+export const ReflowTrigger = () => {
+  const boxRef = useRef<HTMLDivElement>(null);
+
+  // 1️⃣ 스타일 변경 후 즉시 offsetWidth 읽기 (리플로우 발생 가능)
+  const handleReflowTest = () => {
+    if (boxRef.current == null) return;
+
+    boxRef.current.style.width = '200px';
+    console.log(boxRef.current.offsetWidth);
+  };
+
+  // 2️⃣ 그냥 offsetWidth 읽기
+  const handleNoReflowTest = () => {
+    if (boxRef.current == null) return;
+    console.log(boxRef.current.offsetWidth);
+  };
+
+  // 3️⃣ paint만 수행하기
+  const handleChangeBackground = () => {
+    if (boxRef.current == null) return;
+    boxRef.current.style.background = 'orange';
+  };
+
+  return (
+    <div>
+      <h2>React 리플로우 테스트</h2>
+      <div
+        ref={boxRef}
+        style={{
+          width: '100px',
+          height: '100px',
+          backgroundColor: 'lightblue',
+          transition: 'width 0.3s',
+        }}
+      />
+      <button onClick={handleReflowTest}>DOM 조작하고 offsetWidth 바로 읽기</button>
+      <button onClick={handleNoReflowTest}>그냥 offsetWidth 읽기</button>
+      <button onClick={handleChangeBackground}>paint만 트리거하기</button>
+    </div>
+  );
+};


### PR DESCRIPTION
## 🔎 상황

면접 준비를 하면서 `reflow`를 최소화할 수 있는 방법들을 찾아보다가 [이 글](https://tech.kakao.com/posts/685)을 시작으로 [이런 글](https://gist.github.com/paulirish/5d52fb081b3570c81e3a)을 보게 되었다. 요약하자면 리플로우를 유발하는 메서드들에 대한 내용이다.

브라우저는 스타일 계산을 batch로 처리하는데, 이때 `offsetWidth`와 같이 레이아웃 정보를 얻는 메서드를 사용하면 최신 레이아웃 정보를 가져오기 위해 리플로우를 유발한다는 것이다.

## 🐢 문제

궁금한 점이 생겼다. 그럼 **대기 중인 스타일 계산이 없다면 리플로우를 트리거하지 않는걸까?** GPT에게 물어보니 "트리거하지 않는다"라고 했다. 진짜 그런가 궁금해서 테스트를 해보았다.

## 🏃 액션

[이 블로그 글](https://iyu88.github.io/web/2022/10/23/browser-render.html)를 참고해서 결과를 확인할 수 있었다.

### 📸 스타일 변경 후 offsetWidth

![image](https://github.com/user-attachments/assets/321479b6-5414-4bcd-b127-d78f5d3e68c6)

### 📸 그냥 바로 offsetWidth만

정말로 사용만으로는 reflow(layout)가 트리거되지 않았다.

![image](https://github.com/user-attachments/assets/cad502ca-c144-4643-9839-fe6f6bf6d9cf)

### 📸 paint 작업만 (확실하게 reflow가 없는 작업)

![image](https://github.com/user-attachments/assets/d672bab1-c7cb-4060-b962-7bba389962ba)


## 🎉 결과

글만 읽으면 `offsetWidth 사용은 리플로우를 유발합니다!`로 들릴 수도 있는데, 궁금해서 테스트해보니 사용만으로는 유발되지 않고 대기 중인 스타일 변경이 있다면 reflow를 트리거하는 것을 눈으로 확인하니 마음이 편했다. 

가끔 이미 렌더링되어 있는 컴포넌트의 width를 구해서 다른 컴포넌트의 width로 주입해야 하는 일들이 있고는 하는데, 이럴 때 마냥 `offsetWidth`를 사용하는 게 좋지 않은 것이 아님을 알았기 때문이다 🎉 

