### PR TITLE
offsetWidth는 최신 값을 가져오기 위해 reflow를 트리거한다

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -51,13 +51,6 @@ button {
   cursor: pointer;
   transition: border-color 0.25s;
 }
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
 
 @media (prefers-color-scheme: light) {
   :root {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,8 @@ import './index.css';
 // import { CleanUpFunction } from './clean-up-function/CleanUpFunction';
 // import { VirtualDom } from './virtual-dom/VirtualDom';
 // import { BottomSheetTest } from './bottom-sheet/BottomSheetTest';
-import { SingletonTest } from './singleton/axios-example/Test';
+// import { SingletonTest } from './singleton/axios-example/Test';
+import { ReflowTrigger } from './reflow-trigger/ReflowTrigger';
 // import { UseOverlayExample } from './overlay/useOverlay/UseOverlay';
 // import { FlushSync } from './flushSync/FlushSync';
 // import { SyntheticEvent } from './SyntheticEvent/index.tsx';
@@ -22,6 +23,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     {/* <CleanUpFunction /> */}
     {/* <VirtualDom /> */}
     {/* <BottomSheetTest /> */}
-    <SingletonTest />
+    {/* <SingletonTest /> */}
+    <ReflowTrigger />
   </>
 );

--- a/src/reflow-trigger/ReflowTrigger.tsx
+++ b/src/reflow-trigger/ReflowTrigger.tsx
@@ -35,7 +35,6 @@ export const ReflowTrigger = () => {
           width: '100px',
           height: '100px',
           backgroundColor: 'lightblue',
-          //   transition: 'width 0.3s',
         }}
       />
       <button onClick={handleReflowTest}>DOM 조작하고 offsetWidth 바로 읽기</button>

--- a/src/reflow-trigger/ReflowTrigger.tsx
+++ b/src/reflow-trigger/ReflowTrigger.tsx
@@ -1,0 +1,46 @@
+import { useRef } from 'react';
+
+export const ReflowTrigger = () => {
+  const boxRef = useRef<HTMLDivElement>(null);
+
+  // 1️⃣ 스타일 변경 후 즉시 offsetWidth 읽기 (리플로우 발생 가능)
+  const handleReflowTest = () => {
+    if (boxRef.current == null) return;
+
+    boxRef.current.style.width = '1000px';
+    // console.log(boxRef.current.offsetWidth); // <- 실행할 경우 reflow가 유발됨
+
+    boxRef.current.style.width = '200px';
+    console.log(boxRef.current.offsetWidth);
+  };
+
+  // 2️⃣ 그냥 offsetWidth 읽기
+  const handleNoReflowTest = () => {
+    if (boxRef.current == null) return;
+    console.log(boxRef.current.offsetWidth);
+  };
+
+  // 3️⃣ paint만 수행하기
+  const handleChangeBackground = () => {
+    if (boxRef.current == null) return;
+    boxRef.current.style.background = 'orange';
+  };
+
+  return (
+    <div>
+      <h2>React 리플로우 테스트</h2>
+      <div
+        ref={boxRef}
+        style={{
+          width: '100px',
+          height: '100px',
+          backgroundColor: 'lightblue',
+          //   transition: 'width 0.3s',
+        }}
+      />
+      <button onClick={handleReflowTest}>DOM 조작하고 offsetWidth 바로 읽기</button>
+      <button onClick={handleNoReflowTest}>그냥 offsetWidth 읽기</button>
+      <button onClick={handleChangeBackground}>paint만 트리거하기</button>
+    </div>
+  );
+};


### PR DESCRIPTION
## 🔎 상황

면접 준비를 하면서 reflow를 최소화할 수 있는 방법들을 찾아보다가 [이 글](https://tech.kakao.com/posts/685)을 시작으로 [이런 글](https://gist.github.com/paulirish/5d52fb081b3570c81e3a)을 보게 되었다. 요약하자면 리플로우를 유발하는 속성들에 대한 내용이다.

브라우저는 스타일 계산을 batch로 처리하는데, 이때 offsetWidth와 같이 레이아웃 정보를 얻는 속성을 사용하면 최신 레이아웃 정보를 가져오기 위해 리플로우를 유발한다는 것이다.

## 🐢 문제

궁금한 점이 생겼다. 그럼 대기 중인 스타일 계산이 없다면 리플로우를 트리거하지 않는걸까? GPT에게 물어보니 "트리거하지 않는다"라고 했다. 진짜 그런가 궁금해서 테스트를 해보았다.

## 🏃 액션

[이 블로그 글](https://iyu88.github.io/web/2022/10/23/browser-render.html)를 참고해서 결과를 확인할 수 있었다.

### 👇 일부로 중간에 offsetWidth를 사용한 경우 

> 가설: offsetWidth는 최신 값을 가져오기 위해 reflow를 트리거한다.

그렇다 🙆

![image](https://github.com/user-attachments/assets/08e5b1b2-f1d4-4945-97f2-8ecb9711e8d0)

### 👇 DOM 업데이트 이후 offsetWidth를 사용한 경우

reflow가 되긴 했으나, DOM 업데이트로 인해 당연히 reflow가 되긴 한다. 다만, 배치로 처리되어 `style.width`를 2번 처리해도 한번만 호출되었다 🫢

![image](https://github.com/user-attachments/assets/99d9e96c-6168-4beb-ad92-556eefcc715d)

### 👇 DOM 업데이트 없이 offsetWidth 사용한 경우

대기 중인 업데이트가 없기 때문에 단순 읽기만으로는 reflow를 트리거하지 않았다.

![image](https://github.com/user-attachments/assets/877175b5-5f82-4490-a53e-9eeae3749143)

### 👇 paint 작업만 (확실하게 reflow가 없는 작업)

레이아웃을 변경하는 작업이 아니니 당연히 reflow가 호출되지 않았다.

![image](https://github.com/user-attachments/assets/7d080c71-5010-40e4-ab27-c5657f516d40)

## 🎉 결과

글만 읽으면 offsetWidth 사용은 리플로우를 유발합니다!로 들릴 수도 있는데, 궁금해서 테스트해보니 사용만으로는 유발되지 않고 대기 중인 스타일 변경이 있다면 reflow를 트리거하는 것을 눈으로 확인하니 마음이 편했다.

가끔 이미 렌더링되어 있는 컴포넌트의 width를 구해서 다른 컴포넌트의 width로 주입해야 하는 일들이 있고는 하는데, 이럴 때 마냥 offsetWidth를 사용하는 게 좋지 않은 것이 아님을 알았기 때문이다 🎉

