### PR TITLE
ReactNode, ReactElement, JSX.Element 🤿

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,8 @@
 import '../app.css.ts';
 
-import { EmotionExample } from './vanilla-extract/vs-emotion/EmotionExample.tsx';
 // import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { ReactTypes } from './react-types/ReactTypes.tsx';
 
 // import { CleanUpFunction } from './clean-up-function/CleanUpFunction';
 // import { VirtualDom } from './virtual-dom/VirtualDom';
@@ -37,8 +37,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     {/* <ReactElement /> */}
     {/* <VanillaExtractExample /> */}
     {/* <RenderButtonGroupWithVanillaExtract /> */}
-    <EmotionExample />
+    {/* <EmotionExample /> */}
     {/* <VanillaExtractExample /> */}
+    <ReactTypes />
   </>
 );
 

--- a/src/react-types/ReactTypes.tsx
+++ b/src/react-types/ReactTypes.tsx
@@ -1,0 +1,40 @@
+import { JSXElementWrapper, ReactElementWrapper, ReactNodeWrapper } from './Wrapper';
+
+import { TestWrapper } from './TestWrapper';
+
+export const ReactTypes = () => {
+  return (
+    <>
+      {/* 1. ReactNode를 허용하면 모든 타입을 허용할 수 있다.  */}
+      <ReactNodeWrapper wrapper={<div style={{ backgroundColor: 'blueviolet' }} />}>JSX 엘리먼트를 래핑</ReactNodeWrapper>
+      <ReactNodeWrapper wrapper={<TestWrapper />}>리액트 엘리먼트를 래핑</ReactNodeWrapper>
+      <ReactNodeWrapper wrapper={'스트링'}>스트링을 래핑, 그런데 이건 isValidElement가 false여서 그대로 반환될 것</ReactNodeWrapper>
+
+      {/* 2. ReactElement를 허용하면 JSX로 쓸 수 있는 것들만 허용한다. 즉, 원시타입은 허용 X */}
+      <ReactElementWrapper wrapper={<div style={{ backgroundColor: 'blueviolet' }} />}>JSX 엘리먼트를 래핑</ReactElementWrapper>
+      <ReactElementWrapper wrapper={<TestWrapper />}>JSX 엘리먼트를 래핑</ReactElementWrapper>
+      {/* <ReactElementWrapper wrapper="스트링">JSX 엘리먼트를 래핑</ReactElementWrapper> << 아예 타입 에러 발생 */}
+
+      {/* 3. JSX.Element로 허용하면 ReactElement와 거의 동일하지만, JSX.Element는 React.ReactElement<any, any>의 타입 별칭 */}
+      <JSXElementWrapper wrapper={<div style={{ backgroundColor: 'blueviolet' }} />}>JSX 엘리먼트를 래핑</JSXElementWrapper>
+      <JSXElementWrapper wrapper={<TestWrapper />}>JSX 엘리먼트를 래핑</JSXElementWrapper>
+      {/* <ReactElementWrapper wrapper="스트링">JSX 엘리먼트를 래핑</ReactElementWrapper> << 아예 타입 에러 발생 */}
+    </>
+  );
+};
+
+/**
+ * 🤔 ReactElement와 JSX.Element를 어떻게 구분해서 사용하면 좋을까?
+ * - props, type에 제약을 주고 싶다면 ReactElement를 사용하면 좋을 것 같다.
+ * - GPT께서는.. JSX.Element가 간단해서 따로 제네릭을 주고 싶은 경우가 아니라면 JSX.Element가 "JSX를 반환하는 컴포넌트"라는 의도를 명확하게 표현할 수 있어서 좋다고 했다.
+ *      다만, 그 경우엔 조금 더 구체적인 타입을 표현할 때 유리하고, 보통 JSX.Element가 더 읽기 좋고 직관적이어서 많이 사용됩니다. << 라고 했다.
+ * - 나는 별다른 이유가 없다면 ReactElement를 사용해도 좋다고 생각했다.
+ */
+
+// const ReactTypesTest = (): JSX.Element => {
+//   return <div />;
+// };
+
+// const ReactTypesTest2 = (): ReactElement => {
+//   return <div />;
+// };

--- a/src/react-types/TestWrapper.tsx
+++ b/src/react-types/TestWrapper.tsx
@@ -1,0 +1,5 @@
+import { PropsWithChildren } from 'react';
+
+export const TestWrapper = ({ children }: PropsWithChildren) => {
+  return <div style={{ backgroundColor: 'yellowgreen' }}>{children}</div>;
+};

--- a/src/react-types/Wrapper.tsx
+++ b/src/react-types/Wrapper.tsx
@@ -1,0 +1,83 @@
+import { ReactElement, ReactNode, createElement, isValidElement } from 'react';
+
+interface ReactNodeWrapperProps {
+  /**
+   * 1. ReactNode
+   * - JSX + 원시타입 + 배열 + null/undefined 등 모든 타입을 허용한다.
+   * - 디자인 시스템에서는 렌더링이 가능한 모든 타입을 유연하게 허용하기 위해 자주 사용되는 타입인 것 같다
+   * - 텍스트만 올 것이라고 생각해도 string이 아닌 ReactNode를 사용하는 것이 유연하다.
+   *    - 예를 들어, 문장 중 일부 텍스트를 bold 처리하거나 다른 색상을 입혀야 할 때, string일 경우 불가능하지만, ReactNode를 사용하면 단순 string부터 이러한 커스텀까지도 허용하기 때문에 훨씬 유연하다.
+   * - 기능이 아닌 렌더링이 목적인 prop이라면 ReactNode를 사용하는 것이 유연하다.
+   */
+  wrapper: ReactNode;
+  children: ReactNode;
+}
+
+export const ReactNodeWrapper = (props: ReactNodeWrapperProps) => {
+  const { wrapper, children } = props;
+  /**
+   * isValidElement는 주어진 객체가 React 엘리먼트인지 확인
+   * - wrapper가 React 엘리먼트가 아닌 경우(예: 문자열, 숫자 등)에는 createElement를 사용할 수 없기 때문에 이 검사가 필요
+   * - 이 검사가 없으면 wrapper가 원시 타입일 때 타입 에러가 발생할 수 있다.
+   *
+   * 아래 타입은 ReactElement의 타입으로, isValidElement가 true라면 다음 타입을 가지고 있음을 의미한다.
+   *  type: T;
+   *  props: P;
+   *  key: string | null;
+   */
+  if (isValidElement(wrapper)) {
+    return createElement(wrapper.type, wrapper.props, children);
+  }
+
+  return children;
+};
+
+interface ReactElementWrapperProps {
+  /**
+   * 2. ReactElement
+   * - React.createElement로 반환된 결과 타입
+   * - 즉, React.createElement가 호출되어 만들어진 결과만이 이 타입으로 허용된다.
+   * - 즉, 원시 타입을 허용되지 않고, React는 JSX를 createElement로 변환하기 때문에
+   *    - <MyComponent />나 <div />는 허용되지만, '스트링'과 같은 원시는 허용되지 않는다.
+   * - 지금처럼 조작(래핑, props 조집)을 해야 할 때는 type, props, key를 가지고 있는 ReactElement를 사용하는 것이 명확할 것 같다.
+   *    물론 ReactNode로 받고 내부에서 isValidElement로 검사하는 방법도 있지만,
+   *    개발자 입장에서는 타입 에러를 즉시 확인할 수 있는 ReactElement를 사용하는 것이 더 명확
+   *    이렇게 하면 코드 내부 구현을 살펴볼 필요 없이 컴파일 단계에서 잘못된 타입 사용을 바로 알 수 있다. (🤔 뭐야 타입 에러는 안 나는데 왜 안돼? 방지)
+   * - ReactElement 타입을 먼저 고려하고 쓰지 못하는 상황이라면 JSX.Element를 사용할 것 같다.
+   *   예를 들어, 타사 라이브러리에서 JSX.Element 타입을 요구하는 경우나,
+   *   컴포넌트의 반환 타입을 명시할 때(function Component(): JSX.Element)와 같은 상황에서 사용할 수 있다.
+   */
+  wrapper: ReactElement;
+  children: ReactNode;
+}
+
+export const ReactElementWrapper = (props: ReactElementWrapperProps) => {
+  const { wrapper, children } = props;
+  /**
+   * ReactElement로 타입을 걸어둘 경우 `isValidElement`를 검사하지 않아도 된다.
+   * 왜냐하면 그 자체가 isValidElement를 검사하는 것이기 때문이다.
+   */
+  return createElement(wrapper.type, wrapper.props, children);
+};
+
+interface JSXElementWrapperProps {
+  /**
+   * 3. JSX.Element
+   * - JSX 문법으로 생성된 요소
+   * - ReactElement와 거의 동일하지만, JSX.Element는 React.ReactElement<any, any>의 타입 별칭
+   * - 즉, JSX.Element는 ReactElement의 제네릭 타입 매개변수를 any로 고정한 것
+   * - 구분해서 사용하는 방법:
+   *   1. 컴포넌트의 반환 타입으로는 JSX.Element를 주로 사용 (예: function MyComponent(): JSX.Element)
+   *   2. 구체적인 타입 정보가 필요한 경우 ReactElement<P, T>를 사용 (예: props 조작이 필요한 경우)
+   *   3. 일반적인 props 타입에서는 ReactElement가 더 명확한 타입 체크를 제공
+   *   4. 단순히 JSX를 받는 경우에는 JSX.Element로도 충분함
+   * - isValidElement로도 true를 반환한다.
+   */
+  wrapper: JSX.Element;
+  children: ReactNode;
+}
+
+export const JSXElementWrapper = (props: JSXElementWrapperProps) => {
+  const { wrapper, children } = props;
+  return createElement(wrapper.type, wrapper.props, children);
+};


### PR DESCRIPTION
## 🔎 상황

`ReactNode`는 렌더링할 수 있는 모든 타입이라, 유연함을 제공하기 위해 자주 사용하는 타입이다. 평소에 `ReactElement`, `JSX.Element` 타입에 대해 알고는 있었는데 자주 사용하지 않으니까 매번 까먹어서.. 이번에 여러가지 예제 만들어보면서 익혀보았다.

## 🏃 액션

### 간단 정의

- ReactNode: 렌더링할 수 있는 모든 타입. 원시타입부터 JSX 요소, null/undefined 모두 허용한다.
- ReactElement: `React.createElement()`의 결과로 생성되는 React 요소 객체. `<div />`나 `<MyComponent />`같이 createElement로 컴파일되는 형태가 허용된다.
- JSX.Element: `interface Element extends React.ReactElement<any, any> {}`이다. 

### 어떨 때 ReactNode가 아니라 ReactElement를 사용하면 될까?

> 조작이 필요하다면 ReactElement

사실 `ReactNode`로 받고 내부에서 `isValidElement`로 검사를 하면 `ReactElement`인 경우를 분기처리할 수 있긴 하다.
보통 이럴 경우 함수든 뭐든 valid할 때의 액션을 네이밍으로 표현할텐데, valid하지 않은 경우에 대해서는 컴파일 에러가 발생하지는 않는데 액션이 처리되지 않을 것이다.

이럴 경우에는 `ReactElement`로 좁혀서 이를 처리할 수 없는 나머지 타입에 대해서는 컴파일 에러가 발생하도록 하는 게 명확할 것 같다.


### 어땔 때 ReactElement가 아니라 JSX.Element를 사용하면 될까?

> 보통 return 타입으로는 JSX.Element, prop으로는 ReactElement를 사용하는 듯 하다?

`JSX.Element`가 `ReactElement<any, any>`라 별 이유 없다면 `ReactElement`를 사용하면 될 것이라고 생각 들었다. GPT 왈.. `JSX.Element`가 간단해서 따로 제네릭을 주고 싶은 경우가 아니라면 `JSX.Element`가 "JSX를 반환하는 컴포넌트"라는 의도를 명확하게 표현할 수 있어서 좋다고 했다.

[chakra](https://chakra-ui.com/), [mui](https://mui.com/)의 경우를 좀 살펴보았다.

- return 타입으로는 `JSX.Element`
- prop 타입으로는 `ReactElement`

둘 다 위와 같은 패턴으로 사용했다.

## 🎉 결과

안다고 착각하지 말고 한번 딥다이브해서 알아보고 흡수하기 ~ . ~

<img src="https://github.com/user-attachments/assets/b4e1d147-87f9-450b-aee7-e9d6ff26dbdb" width="300" />



